### PR TITLE
Created unwrapping Harmony Patch

### DIFF
--- a/PlaylistManager/HarmonyPatches/LevelCollectionTableView_HandleDidSelectRowEvent.cs
+++ b/PlaylistManager/HarmonyPatches/LevelCollectionTableView_HandleDidSelectRowEvent.cs
@@ -1,0 +1,61 @@
+﻿using BeatSaberPlaylistsLib.Types;
+using HarmonyLib;
+using HMUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace PlaylistManager.HarmonyPatches
+{
+    /*
+     * Unwraps IPlaylistSong (if selected) and returns an IPreviewBeatmapLevel
+     * Also has an event with the unwrapped PlaylistSong (or BeatmapLevel) for PlaylistManager to use
+     * Any playlist GUI mod that loads playlist songs into a LevelCollectionTable MUST use this patcher so other mods remain compatible
+     */
+
+    [HarmonyPatch(typeof(LevelCollectionTableView), "HandleDidSelectRowEvent",
+        new Type[] {
+        typeof(TableView), typeof(int)})]
+    public class LevelCollectionTableView_HandleDidSelectRowEvent
+    {
+        internal static event Action<IPreviewBeatmapLevel> didSelectLevelEvent;
+        internal static readonly MethodInfo _unwrapPlaylistSong = SymbolExtensions.GetMethodInfo((IPreviewBeatmapLevel previewBeatmapLevel) => UnwrapPlaylistSong(previewBeatmapLevel));
+
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
+            int index = -1;
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Stfld && codes[i].operand.ToString() == "IPreviewBeatmapLevel _selectedPreviewBeatmapLevel")
+                {
+                    if (codes[i-1].opcode != OpCodes.Ldnull)
+                    {
+                        index = i;
+                    }
+                }
+            }
+            if (index != -1)
+            {
+                CodeInstruction newInstruction = new CodeInstruction(OpCodes.Callvirt, _unwrapPlaylistSong);
+                codes.Insert(index, newInstruction);
+            }
+            return codes.AsEnumerable();
+        }
+
+        internal static IPreviewBeatmapLevel UnwrapPlaylistSong(IPreviewBeatmapLevel previewBeatmapLevel)
+        {
+            didSelectLevelEvent.Invoke(previewBeatmapLevel);
+            if (previewBeatmapLevel is IPlaylistSong)
+            {
+                return ((IPlaylistSong)previewBeatmapLevel).PreviewBeatmapLevel;
+            }
+            else
+            {
+                return previewBeatmapLevel;
+            }
+        }
+    }
+}

--- a/PlaylistManager/HarmonyPatches/TableViewScroller_HandleJoystickWasNotCenteredThisFrame.cs
+++ b/PlaylistManager/HarmonyPatches/TableViewScroller_HandleJoystickWasNotCenteredThisFrame.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using UnityEngine;
 
-namespace PlaylistLoaderLite.HarmonyPatches
+namespace PlaylistManager.HarmonyPatches
 {
     [HarmonyPatch(typeof(TableViewScroller), "HandleJoystickWasNotCenteredThisFrame",
         new Type[] {

--- a/PlaylistManager/Managers/PlaylistUIManager.cs
+++ b/PlaylistManager/Managers/PlaylistUIManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Zenject;
 using PlaylistManager.Interfaces;
 using PlaylistManager.UI;
+using PlaylistManager.HarmonyPatches;
 
 namespace PlaylistManager.Managers
 {
@@ -13,16 +14,14 @@ namespace PlaylistManager.Managers
         PlaylistViewController playlistViewController;
         ILevelCollectionUpdater levelCollectionUpdater;
 
-        LevelCollectionViewController levelCollectionViewController;
         List<IPreviewBeatmapLevelUpdater> previewBeatmapLevelUpdaters;
 
-        PlaylistUIManager(AnnotatedBeatmapLevelCollectionsViewController annotatedBeatmapLevelCollectionsViewController, SelectLevelCategoryViewController selectLevelCategoryViewController, PlaylistViewController playlistViewController, ILevelCollectionUpdater levelCollectionUpdater, LevelCollectionViewController levelCollectionViewController, List<IPreviewBeatmapLevelUpdater> previewBeatmapLevelUpdaters)
+        PlaylistUIManager(AnnotatedBeatmapLevelCollectionsViewController annotatedBeatmapLevelCollectionsViewController, SelectLevelCategoryViewController selectLevelCategoryViewController, PlaylistViewController playlistViewController, ILevelCollectionUpdater levelCollectionUpdater, List<IPreviewBeatmapLevelUpdater> previewBeatmapLevelUpdaters)
         {
             this.annotatedBeatmapLevelCollectionsViewController = annotatedBeatmapLevelCollectionsViewController;
             this.selectLevelCategoryViewController = selectLevelCategoryViewController;
             this.playlistViewController = playlistViewController;
             this.levelCollectionUpdater = levelCollectionUpdater;
-            this.levelCollectionViewController = levelCollectionViewController;
             this.previewBeatmapLevelUpdaters = previewBeatmapLevelUpdaters;
         }
 
@@ -31,7 +30,7 @@ namespace PlaylistManager.Managers
             annotatedBeatmapLevelCollectionsViewController.didSelectAnnotatedBeatmapLevelCollectionEvent -= DidSelectAnnotatedBeatmapLevelCollectionEvent;
             selectLevelCategoryViewController.didSelectLevelCategoryEvent -= SelectLevelCategoryViewController_didSelectLevelCategoryEvent;
             playlistViewController.didSelectAnnotatedBeatmapLevelCollectionEvent -= DidSelectAnnotatedBeatmapLevelCollectionEvent;
-            levelCollectionViewController.didSelectLevelEvent -= LevelCollectionViewController_didSelectLevelEvent;
+            LevelCollectionTableView_HandleDidSelectRowEvent.didSelectLevelEvent -= LevelCollectionViewController_didSelectLevelEvent;
         }
 
         public void Initialize()
@@ -39,10 +38,10 @@ namespace PlaylistManager.Managers
             annotatedBeatmapLevelCollectionsViewController.didSelectAnnotatedBeatmapLevelCollectionEvent += DidSelectAnnotatedBeatmapLevelCollectionEvent;
             selectLevelCategoryViewController.didSelectLevelCategoryEvent += SelectLevelCategoryViewController_didSelectLevelCategoryEvent;
             playlistViewController.didSelectAnnotatedBeatmapLevelCollectionEvent += DidSelectAnnotatedBeatmapLevelCollectionEvent;
-            levelCollectionViewController.didSelectLevelEvent += LevelCollectionViewController_didSelectLevelEvent;
+            LevelCollectionTableView_HandleDidSelectRowEvent.didSelectLevelEvent += LevelCollectionViewController_didSelectLevelEvent;
         }
 
-        private void LevelCollectionViewController_didSelectLevelEvent(LevelCollectionViewController levelCollectionViewController, IPreviewBeatmapLevel beatmapLevel)
+        private void LevelCollectionViewController_didSelectLevelEvent(IPreviewBeatmapLevel beatmapLevel)
         {
             foreach (IPreviewBeatmapLevelUpdater previewBeatmapLevelUpdater in previewBeatmapLevelUpdaters)
             {

--- a/PlaylistManager/PlaylistManager.csproj
+++ b/PlaylistManager/PlaylistManager.csproj
@@ -162,6 +162,7 @@
   <ItemGroup>
     <Compile Include="HarmonyPatches\AnnotatedBeatmapLevelCollectionTableCell_SetData.cs" />
     <Compile Include="HarmonyPatches\AnnotatedBeatmapLevelCollectionsViewController_SetData.cs" />
+    <Compile Include="HarmonyPatches\LevelCollectionTableView_HandleDidSelectRowEvent.cs" />
     <Compile Include="HarmonyPatches\LevelFilteringNavigationController_UpdateSecondChildControllerContent.cs" />
     <Compile Include="HarmonyPatches\TableViewScroller_HandleJoystickWasNotCenteredThisFrame.cs" />
     <Compile Include="Installers\PlaylistViewInstaller.cs" />

--- a/PlaylistManager/Properties/AssemblyInfo.cs
+++ b/PlaylistManager/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
- Created unwrapping Harmony Patch
- Fixed mistake where namespace for TableViewScroller Harmony Patch was still PlaylistLoaderLite